### PR TITLE
Fixed bug where blur isn't getting fired

### DIFF
--- a/jquery.trap.js
+++ b/jquery.trap.js
@@ -65,6 +65,7 @@ IS" AND ANY EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED.
 				nextIndex = prevIndex;
 			}
 			
+			curElt.blur();
 			curElt = $focussable.eq(nextIndex);
 			curElt.focus();
 		


### PR DESCRIPTION
Fixed bug where blur isn't getting fired on the element that is losing focus.  If functions are hooked up to any blur events on the focusable elements then using trap would have prevented them from being called.
